### PR TITLE
Instance printing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "",
   "main": "src/Imandra_client.bs.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "bsb -make-world"
+    "test": "jest -i",
+    "build": "bsb -make-world",
+    "watch": "bsb -make-world -w"
   },
   "author": "",
   "license": "ISC",

--- a/src/Imandra_client.ml
+++ b/src/Imandra_client.ml
@@ -278,7 +278,7 @@ let start (passedOpts : imandraOptions) : (Node.Child_process.spawnResult * Serv
       getPort ()
       |> Js.Promise.then_ (fun port ->
           (* Always set reason to load the reason parser. Syntax is specified per-call *)
-          let args = [|"-reason"; "-port"; (string_of_int port)|] in
+          let args = [|"--non-interactive"; "-reason"; "-port"; (string_of_int port)|] in
           let np = spawn opts.serverCmd args in
 
           listenForStartupClose np;

--- a/src/Imandra_client.ml
+++ b/src/Imandra_client.ml
@@ -49,6 +49,16 @@ module PrinterDetails = struct
     { name : string
     ; cx_var_name : string
     }
+
+  module Encode = struct
+    let t (t : t) : Js.Json.t =
+      Js.Dict.fromList
+        [ ("name", Js.Json.string t.name)
+        ; ("cx_var_name", Js.Json.string t.cx_var_name)
+        ]
+      |> Js.Json.object_
+
+  end
 end
 
 module Src = struct
@@ -98,18 +108,11 @@ module Request = struct
 
   module Encode = struct
 
-    let printerDetails (t : PrinterDetails.t) : Js.Json.t =
-      Js.Dict.fromList
-        [ ("name", Js.Json.string t.name)
-        ; ("cx_var_name", Js.Json.string t.cx_var_name)
-        ]
-      |> Js.Json.object_
-
     let reqSrc (t : reqSrc) : Js.Json.t =
       Js.Dict.fromList
         ([ ("src", Src.Encode.t t.src)
          ]
-         |> append_opt_key "instancePrinter" printerDetails t.instancePrinter
+         |> append_opt_key "instance_printer" PrinterDetails.Encode.t t.instancePrinter
         )
       |> Js.Json.object_
 
@@ -117,7 +120,7 @@ module Request = struct
       Js.Dict.fromList
         ([ ("name", Js.Json.string t.name)
          ]
-         |> append_opt_key "instancePrinter" printerDetails t.instancePrinter
+         |> append_opt_key "instance_printer" PrinterDetails.Encode.t t.instancePrinter
         )
       |> Js.Json.object_
   end
@@ -282,7 +285,7 @@ let start (passedOpts : imandraOptions) : (Node.Child_process.spawnResult * Serv
       getPort ()
       |> Js.Promise.then_ (fun port ->
           (* Always set reason to load the reason parser. Syntax is specified per-call *)
-          let args = [|"--non-interactive"; "-reason"; "-port"; (string_of_int port)|] in
+          let args = [|"-reason"; "-port"; (string_of_int port)|] in
           let np = spawn opts.serverCmd args in
 
           listenForStartupClose np;

--- a/src/Imandra_client.mli
+++ b/src/Imandra_client.mli
@@ -47,29 +47,32 @@ module Syntax : sig
     | Reason
 end
 
-module Verify : sig
-  type model =
-    { language : string
+module Src : sig
+  type t =
+    { syntax : Syntax.t
     ; src : string
     }
+end
 
-  type counterexample =
-    { model : model }
+module Response : sig
+  type instance =
+    { model : Src.t
+    ; type_ : string
+    ; printed : string option
+    }
+end
 
+module Verify : sig
   type unknownResult =
     { reason: string }
 
   type refutedResult =
-    { counterexample: counterexample }
+    { instance: Response.instance }
 
   type verifyResult =
     | Proved
     | Unknown of unknownResult
     | Refuted of refutedResult
-
-  module Decode : sig
-    val verifyResult : Js.Json.t -> verifyResult
-  end
 
   val bySrc : ?instancePrinter:PrinterDetails.t -> syntax:Syntax.t -> src:string -> ServerInfo.t -> (verifyResult with_json, error with_json ) Belt.Result.t Js.Promise.t
   val byName : ?instancePrinter:PrinterDetails.t -> name:string -> ServerInfo.t -> (verifyResult with_json, error with_json ) Belt.Result.t Js.Promise.t
@@ -80,28 +83,16 @@ module Eval : sig
 end
 
 module Instance : sig
-  type model =
-    { language : string
-    ; src : string
-    }
-
-  type example =
-    { model : model }
-
   type unknownResult =
     { reason: string }
 
   type satResult =
-    { example: example }
+    { instance: Response.instance }
 
   type instanceResult =
     | Sat of satResult
     | Unknown of unknownResult
     | Unsat
-
-  module Decode : sig
-    val instanceResult : Js.Json.t -> instanceResult
-  end
 
   val bySrc : ?instancePrinter:PrinterDetails.t -> syntax:Syntax.t -> src:string -> ServerInfo.t -> (instanceResult with_json, error with_json) Belt.Result.t Js.Promise.t
   val byName : ?instancePrinter:PrinterDetails.t -> name:string -> ServerInfo.t -> (instanceResult with_json, error with_json) Belt.Result.t Js.Promise.t

--- a/src/Imandra_client.mli
+++ b/src/Imandra_client.mli
@@ -47,7 +47,7 @@ module Syntax : sig
     | Reason
 end
 
-module Src : sig
+module Model : sig
   type t =
     { syntax : Syntax.t
     ; src : string
@@ -56,7 +56,7 @@ end
 
 module Response : sig
   type instance =
-    { model : Src.t
+    { model : Model.t
     ; type_ : string
     ; printed : string option
     }
@@ -64,7 +64,7 @@ end
 
 module Verify : sig
   type unknownResult =
-    { reason: string }
+    { reason : string }
 
   type refutedResult =
     { instance: Response.instance }

--- a/src/Imandra_client.mli
+++ b/src/Imandra_client.mli
@@ -5,6 +5,13 @@ type imandraOptions =
   ; serverCmd : string [@bs.optional]
   } [@@bs.deriving abstract]
 
+module PrinterDetails : sig
+  type t =
+    { name : string
+    ; cx_var_name : string
+    }
+end
+
 module ServerInfo : sig
   type t =
     { port : int
@@ -19,8 +26,8 @@ module ServerInfo : sig
     val t : Js.Json.t -> t
   end
 
-  val to_file : ?filename:string -> t -> unit
-  val from_file : ?filename:string -> unit -> t
+  val toFile : ?filename:string -> t -> unit
+  val fromFile : ?filename:string -> unit -> t
   val cleanup : ?filename:string -> unit -> unit
 
 end
@@ -64,12 +71,12 @@ module Verify : sig
     val verifyResult : Js.Json.t -> verifyResult
   end
 
-  val by_src : syntax:Syntax.t -> src:string -> ServerInfo.t -> (verifyResult with_json, error with_json ) Belt.Result.t Js.Promise.t
-  val by_name : name:string -> ServerInfo.t -> (verifyResult with_json, error with_json ) Belt.Result.t Js.Promise.t
+  val bySrc : ?instancePrinter:PrinterDetails.t -> syntax:Syntax.t -> src:string -> ServerInfo.t -> (verifyResult with_json, error with_json ) Belt.Result.t Js.Promise.t
+  val byName : ?instancePrinter:PrinterDetails.t -> name:string -> ServerInfo.t -> (verifyResult with_json, error with_json ) Belt.Result.t Js.Promise.t
 end
 
 module Eval : sig
-  val by_src : syntax:Syntax.t -> src:string -> ServerInfo.t -> (unit with_json, error with_json) Belt.Result.t Js.Promise.t
+  val bySrc : syntax:Syntax.t -> src:string -> ServerInfo.t -> (unit with_json, error with_json) Belt.Result.t Js.Promise.t
 end
 
 module Instance : sig
@@ -96,8 +103,8 @@ module Instance : sig
     val instanceResult : Js.Json.t -> instanceResult
   end
 
-  val by_src : syntax:Syntax.t -> src:string -> ServerInfo.t -> (instanceResult with_json, error with_json) Belt.Result.t Js.Promise.t
-  val by_name : name:string -> ServerInfo.t -> (instanceResult with_json, error with_json) Belt.Result.t Js.Promise.t
+  val bySrc : ?instancePrinter:PrinterDetails.t -> syntax:Syntax.t -> src:string -> ServerInfo.t -> (instanceResult with_json, error with_json) Belt.Result.t Js.Promise.t
+  val byName : ?instancePrinter:PrinterDetails.t -> name:string -> ServerInfo.t -> (instanceResult with_json, error with_json) Belt.Result.t Js.Promise.t
 end
 
 val reset : ServerInfo.t -> (unit with_json, error with_json) Belt.Result.t Js.Promise.t

--- a/src/__tests__/Imandra_client_tests.ml
+++ b/src/__tests__/Imandra_client_tests.ml
@@ -10,7 +10,6 @@ let () =
       let open Imandra_client in
       Imandra_client.start
         (imandraOptions
-           ~serverCmd:"/Users/dave/dev/ai/imandra_network/script/imandra-http-server-local-dev"
            ~debug:true ())
       |> Js.Promise.then_ (fun (np, isi) ->
           runningNodeProcess := Some np;

--- a/src/__tests__/Imandra_client_tests.ml
+++ b/src/__tests__/Imandra_client_tests.ml
@@ -15,8 +15,8 @@ let () =
       |> Js.Promise.then_ (fun (np, isi) ->
           runningNodeProcess := Some np;
           (* check serialisation works *)
-          Imandra_client.ServerInfo.to_file isi;
-          let from_disk = Imandra_client.ServerInfo.from_file () in
+          Imandra_client.ServerInfo.toFile isi;
+          let from_disk = Imandra_client.ServerInfo.fromFile () in
           runningImandraServerInfo := Some from_disk;
           Js.Promise.resolve ()
         )
@@ -29,7 +29,7 @@ let () =
 let () =
   testPromise ~timeout:20000 "verify refuted" (fun () ->
       let ip = !runningImandraServerInfo |> Belt.Option.getExn in
-      Imandra_client.Verify.by_src ip ~syntax ~src:"fun x -> x = 3"
+      Imandra_client.Verify.bySrc ip ~syntax ~src:"fun x -> x = 3"
       |> Js.Promise.then_ (function
           | Belt.Result.Ok (Imandra_client.Verify.Refuted _, _) -> Js.Promise.resolve pass
           | Belt.Result.Ok _ -> Js.Promise.resolve (fail "wrong verify result")
@@ -40,10 +40,10 @@ let () =
 let () =
   testPromise ~timeout:20000 "verify by name proved" (fun () ->
       let ip = !runningImandraServerInfo |> Belt.Option.getExn in
-      Imandra_client.Eval.by_src ip ~syntax ~src:"let rev_rev x = 3 = 3"
+      Imandra_client.Eval.bySrc ip ~syntax ~src:"let rev_rev x = 3 = 3"
       |> Js.Promise.then_ (function
           | Belt.Result.Ok _ ->
-            Imandra_client.Verify.by_name ip ~name:"rev_rev"
+            Imandra_client.Verify.byName ip ~name:"rev_rev"
             |> Js.Promise.then_ (function
                 | Belt.Result.Ok (Imandra_client.Verify.Proved, _) -> Js.Promise.resolve pass
                 | Belt.Result.Ok _ -> Js.Promise.resolve (fail "wrong verify result")
@@ -56,7 +56,7 @@ let () =
 let () =
   testPromise ~timeout:20000 "instance" (fun () ->
       let ip = !runningImandraServerInfo |> Belt.Option.getExn in
-      Imandra_client.Instance.by_src ip ~syntax ~src:"fun x -> List.length x > 4"
+      Imandra_client.Instance.bySrc ip ~syntax ~src:"fun x -> List.length x > 4"
       |> Js.Promise.then_ (function
           | Belt.Result.Ok (Imandra_client.Instance.Sat _, _) -> Js.Promise.resolve pass
           | Belt.Result.Ok (_, _) -> Js.Promise.resolve (fail "instance result not satisifed")
@@ -67,7 +67,7 @@ let () =
 let () =
   testPromise ~timeout:20000 "eval failure" (fun () ->
       let ip = !runningImandraServerInfo |> Belt.Option.getExn in
-      Imandra_client.Eval.by_src ip ~syntax ~src:"garbage"
+      Imandra_client.Eval.bySrc ip ~syntax ~src:"garbage"
       |> Js.Promise.then_ (function
           | Belt.Result.Ok (_, _) -> Js.Promise.resolve (fail "unexpected success")
           | Belt.Result.Error (e, _) ->
@@ -78,7 +78,7 @@ let () =
 let () =
   testPromise ~timeout:20000 "eval failure for mod_use" (fun () ->
       let ip = !runningImandraServerInfo |> Belt.Option.getExn in
-      Imandra_client.Eval.by_src ip ~syntax ~src:"#mod_use \"lol_no_file.iml\""
+      Imandra_client.Eval.bySrc ip ~syntax ~src:"#mod_use \"lol_no_file.iml\""
       |> Js.Promise.then_ (function
           | Belt.Result.Ok (_, _) -> Js.Promise.resolve (fail "unexpected success")
           | Belt.Result.Error (e, _j) ->
@@ -89,7 +89,7 @@ let () =
 let () =
   testPromise ~timeout:20000 "eval reason" (fun () ->
       let ip = !runningImandraServerInfo |> Belt.Option.getExn in
-      Imandra_client.Eval.by_src ip ~syntax:Reason ~src:"let myfn = (x) => x == 3;"
+      Imandra_client.Eval.bySrc ip ~syntax:Reason ~src:"let myfn = (x) => x == 3;"
       |> Js.Promise.then_ (function
           | Belt.Result.Ok (_, _) ->
             Js.Promise.resolve (pass)
@@ -101,7 +101,7 @@ let () =
 let () =
   testPromise ~timeout:20000 "verify reason" (fun () ->
       let ip = !runningImandraServerInfo |> Belt.Option.getExn in
-      Imandra_client.Eval.by_src ip ~syntax:Reason ~src:"(x) => x == 3;"
+      Imandra_client.Eval.bySrc ip ~syntax:Reason ~src:"(x) => x == 3;"
       |> Js.Promise.then_ (function
           | Belt.Result.Ok (_, _) ->
             Js.Promise.resolve (pass)
@@ -113,7 +113,7 @@ let () =
 let () =
   testPromise ~timeout:20000 "verify ocaml again" (fun () ->
       let ip = !runningImandraServerInfo |> Belt.Option.getExn in
-      Imandra_client.Verify.by_src ip ~syntax ~src:"fun x -> x = 3"
+      Imandra_client.Verify.bySrc ip ~syntax ~src:"fun x -> x = 3"
       |> Js.Promise.then_ (function
           | Belt.Result.Ok (_, _) ->
             Js.Promise.resolve (pass)
@@ -126,16 +126,16 @@ let () =
 let () =
   testPromise ~timeout:20000 "reset" (fun () ->
       let ip = !runningImandraServerInfo |> Belt.Option.getExn in
-      Imandra_client.Eval.by_src ip ~syntax ~src:"let to_be_reset x = x = 3"
+      Imandra_client.Eval.bySrc ip ~syntax ~src:"let to_be_reset x = x = 3"
       |> Js.Promise.then_ (function
           | Belt.Result.Ok (_, _) ->
-            Imandra_client.Verify.by_name ip ~name:"to_be_reset"
+            Imandra_client.Verify.byName ip ~name:"to_be_reset"
             |> Js.Promise.then_ (function
                 | Belt.Result.Ok (_, _) ->
                   Imandra_client.reset ip
                   |> Js.Promise.then_ (function
                       | Belt.Result.Ok (_, _) ->
-                        Imandra_client.Verify.by_name ip ~name:"to_be_reset"
+                        Imandra_client.Verify.byName ip ~name:"to_be_reset"
                         |> Js.Promise.then_ (function
                             | Belt.Result.Error (e, _j) ->
                               Js.Promise.resolve (Expect.toContainString "Unknown verification goal" (`Just e))


### PR DESCRIPTION
- More consistent (reason-style) casing
- Refactor JSON decoders and updates for response changes around models in new `imandra-http-server` version
- Add `instancePrinter` arg to allow printing of instances with a pre-loaded `instanceT -> string` function passed to supporting endpoints