### PR TITLE
Shutdown endpoint

### DIFF
--- a/src/Imandra_client.ml
+++ b/src/Imandra_client.ml
@@ -321,7 +321,7 @@ module Instance = struct
 end
 
 let reset (p : Server_info.t) : (unit, Error.t) Belt.Result.t Js.Promise.t =
-    Fetch.fetchWithRequestInit
-      (Fetch.Request.make (p.base_url ^ "/reset"))
-      (Fetch.RequestInit.make ~method_:Post ())
-    |> Js.Promise.then_ (handle_response (Decoders_bs.Decode.succeed ()))
+  Fetch.fetchWithRequestInit
+    (Fetch.Request.make (p.base_url ^ "/reset"))
+    (Fetch.RequestInit.make ~method_:Post ())
+  |> Js.Promise.then_ (handle_response (Decoders_bs.Decode.succeed ()))

--- a/src/Imandra_client.ml
+++ b/src/Imandra_client.ml
@@ -231,7 +231,7 @@ let stop (np : Node.Child_process.spawnResult) : unit Js.Promise.t =
     )
   |> Js.Promise.then_ (fun _ -> Js.Promise.resolve ())
 
-let handle_response decoder res =
+let handle_json_response decoder res =
   let status = Fetch.Response.status res in
   Fetch.Response.json res
   |> Js.Promise.then_ (fun json ->
@@ -260,7 +260,7 @@ module Verify = struct
     Fetch.fetchWithRequestInit
       (Fetch.Request.make (p.base_url ^ "/verify/by-src"))
       (Fetch.RequestInit.make ~method_:Post ~body ())
-    |> Js.Promise.then_ (handle_response D.Response.verify_result)
+    |> Js.Promise.then_ (handle_json_response D.Response.verify_result)
 
   let by_name
       ?(instance_printer: Api.Request.printer_details option)
@@ -273,7 +273,7 @@ module Verify = struct
     Fetch.fetchWithRequestInit
       (Fetch.Request.make (p.base_url ^ "/verify/by-name"))
       (Fetch.RequestInit.make ~method_:Post ~body ())
-    |> Js.Promise.then_ (handle_response D.Response.verify_result)
+    |> Js.Promise.then_ (handle_json_response D.Response.verify_result)
 end
 
 module Eval = struct
@@ -288,7 +288,7 @@ module Eval = struct
     Fetch.fetchWithRequestInit
       (Fetch.Request.make (p.base_url ^ "/eval/by-src"))
       (Fetch.RequestInit.make ~method_:Post ~body ())
-    |> Js.Promise.then_ (handle_response (Decoders_bs.Decode.succeed ()))
+    |> Js.Promise.then_ (handle_json_response (Decoders_bs.Decode.succeed ()))
 end
 
 module Instance = struct
@@ -304,7 +304,7 @@ module Instance = struct
     Fetch.fetchWithRequestInit
       (Fetch.Request.make (p.base_url ^ "/instance/by-src"))
       (Fetch.RequestInit.make ~method_:Post ~body ())
-    |> Js.Promise.then_ (handle_response D.Response.instance_result)
+    |> Js.Promise.then_ (handle_json_response D.Response.instance_result)
 
   let by_name
       ?(instance_printer: Api.Request.printer_details option)
@@ -317,14 +317,14 @@ module Instance = struct
     Fetch.fetchWithRequestInit
       (Fetch.Request.make (p.base_url ^ "/instance/by-name"))
       (Fetch.RequestInit.make ~method_:Post ~body ())
-    |> Js.Promise.then_ (handle_response D.Response.instance_result)
+    |> Js.Promise.then_ (handle_json_response D.Response.instance_result)
 end
 
 let reset (p : Server_info.t) : (unit, Error.t) Belt.Result.t Js.Promise.t =
   Fetch.fetchWithRequestInit
     (Fetch.Request.make (p.base_url ^ "/reset"))
     (Fetch.RequestInit.make ~method_:Post ())
-  |> Js.Promise.then_ (handle_response (Decoders_bs.Decode.succeed ()))
+  |> Js.Promise.then_ (handle_json_response (Decoders_bs.Decode.succeed ()))
 
 let shutdown (p : Server_info.t) : (unit, Error.t) Belt.Result.t Js.Promise.t =
   Fetch.fetchWithRequestInit

--- a/src/Imandra_client.ml
+++ b/src/Imandra_client.ml
@@ -217,8 +217,6 @@ let start (passed_opts : imandra_options) : (Node.Child_process.spawnResult * Se
       |> ignore
     )
 
-external spawn_kill : Node.Child_process.spawnResult -> int -> unit = "kill" [@@bs.send]
-
 let handle_json_response decoder res =
   let status = Fetch.Response.status res in
   Fetch.Response.json res

--- a/src/Imandra_client.ml
+++ b/src/Imandra_client.ml
@@ -325,3 +325,9 @@ let reset (p : Server_info.t) : (unit, Error.t) Belt.Result.t Js.Promise.t =
     (Fetch.Request.make (p.base_url ^ "/reset"))
     (Fetch.RequestInit.make ~method_:Post ())
   |> Js.Promise.then_ (handle_response (Decoders_bs.Decode.succeed ()))
+
+let shutdown (p : Server_info.t) : (unit, Error.t) Belt.Result.t Js.Promise.t =
+  Fetch.fetchWithRequestInit
+    (Fetch.Request.make (p.base_url ^ "/shutdown"))
+    (Fetch.RequestInit.make ~method_:Post ())
+  |> Js.Promise.then_ (handle_response (Decoders_bs.Decode.succeed ()))

--- a/src/Imandra_client.ml
+++ b/src/Imandra_client.ml
@@ -335,7 +335,7 @@ let shutdown (p : Server_info.t) : (unit, string) Belt.Result.t Js.Promise.t =
   |> Js.Promise.then_ (fun s -> Js.Promise.make (fun ~resolve ~reject:_ ->
       Js.Global.setTimeout (fun () ->
           resolve s [@bs];
-        ) 1200 |> ignore))
+        ) 200 |> ignore))
   |> Js.Promise.then_ (fun _ ->
       Js.Promise.resolve (Belt.Result.Ok ())
     )

--- a/src/Imandra_client.ml
+++ b/src/Imandra_client.ml
@@ -219,18 +219,6 @@ let start (passed_opts : imandra_options) : (Node.Child_process.spawnResult * Se
 
 external spawn_kill : Node.Child_process.spawnResult -> int -> unit = "kill" [@@bs.send]
 
-let stop (np : Node.Child_process.spawnResult) : unit Js.Promise.t =
-  Js.Promise.make (fun ~resolve ~reject:_ ->
-      let handler = ref (fun _ -> ()) in
-      handler := (fun code ->
-          np |. spawn_off (`close !handler) |> ignore;
-          resolve code [@bs];
-        );
-      np |. spawn_on (`close !handler) |> ignore;
-      np |. spawn_kill 2 |> ignore;
-    )
-  |> Js.Promise.then_ (fun _ -> Js.Promise.resolve ())
-
 let handle_json_response decoder res =
   let status = Fetch.Response.status res in
   Fetch.Response.json res

--- a/src/Imandra_client.mli
+++ b/src/Imandra_client.mli
@@ -88,3 +88,11 @@ end
 val reset
   : Server_info.t
   -> (unit, Error.t) Belt.Result.t Js.Promise.t
+
+val status
+  : Server_info.t
+  -> (unit, string) Belt.Result.t Js.Promise.t
+
+val shutdown
+  : Server_info.t
+  -> (unit, string) Belt.Result.t Js.Promise.t

--- a/src/Imandra_client.mli
+++ b/src/Imandra_client.mli
@@ -30,8 +30,6 @@ end
 
 val start : imandra_options -> (Node.Child_process.spawnResult * Server_info.t) Js.Promise.t
 
-val stop : Node.Child_process.spawnResult -> unit Js.Promise.t
-
 module Error : sig
   type t =
     | Decoder_error of Decoders_bs.Decode.error

--- a/src/__tests__/Imandra_client_tests.ml
+++ b/src/__tests__/Imandra_client_tests.ml
@@ -175,8 +175,9 @@ let () =
 let () =
   afterAllAsync ~timeout:20000 (fun finish ->
       match !running_node_process with
-      | Some np ->
-        Imandra_client.stop np
+      | Some _np ->
+        let ip = !running_imandra_server_info |> Belt.Option.getExn |> Belt.Result.getExn in
+        Imandra_client.shutdown ip
         |> Js.Promise.then_ (fun _ ->
             running_node_process := None;
             running_imandra_server_info := None;


### PR DESCRIPTION
Support new shutdown endpoint on `imandra-http-server`, use that rather than sending kill signal as shutdown method in tests.